### PR TITLE
Fix policy script path output

### DIFF
--- a/code/DeltaKustoLib/CommandModel/Policies/Caching/AlterCachingPolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/Caching/AlterCachingPolicyCommand.cs
@@ -24,8 +24,8 @@ namespace DeltaKustoLib.CommandModel.Policies.Caching
         public override string CommandFriendlyName => ".alter <entity> policy caching";
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/caching/create/{EntityName}"
-            : $"databases/policies/caching/create";
+            ? $"databases/policies/caching/create/{EntityName}"
+            : $"tables/policies/caching/create";
 
         public AlterCachingPolicyCommand(
             EntityType entityType,

--- a/code/DeltaKustoLib/CommandModel/Policies/Caching/DeleteCachingPolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/Caching/DeleteCachingPolicyCommand.cs
@@ -12,8 +12,8 @@ namespace DeltaKustoLib.CommandModel.Policies.Caching
         public override string CommandFriendlyName => throw new NotImplementedException();
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/caching/delete"
-            : $"db/policies/caching/delete";
+            ? $"databases/policies/caching/delete"
+            : $"tables/policies/caching/delete";
 
         public DeleteCachingPolicyCommand(EntityType entityType, EntityName entityName)
             : base(entityType, entityName)

--- a/code/DeltaKustoLib/CommandModel/Policies/IngestionBatching/AlterIngestionBatchingPolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/IngestionBatching/AlterIngestionBatchingPolicyCommand.cs
@@ -19,8 +19,8 @@ namespace DeltaKustoLib.CommandModel.Policies.IngestionBatching
         public override string CommandFriendlyName => ".alter <entity> policy ingestionbatching";
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/ingestionbatching/create/{EntityName}"
-            : $"databases/policies/ingestionbatching/create";
+            ? $"databases/policies/ingestionbatching/create/{EntityName}"
+            : $"tables/policies/ingestionbatching/create/{EntityName}";
 
         public AlterIngestionBatchingPolicyCommand(
             EntityType entityType,

--- a/code/DeltaKustoLib/CommandModel/Policies/IngestionBatching/DeleteIngestionBatchingPolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/IngestionBatching/DeleteIngestionBatchingPolicyCommand.cs
@@ -18,8 +18,8 @@ namespace DeltaKustoLib.CommandModel.Policies.IngestionBatching
         public override string CommandFriendlyName => ".delete <entity> policy ingestionbatching";
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/ingestionbatching/delete"
-            : $"db/policies/delete";
+            ? $"databases/policies/ingestionbatching/delete/{EntityName}"
+            : $"tables/policies/ingestionbatching/delete/{EntityName}";
 
         public DeleteIngestionBatchingPolicyCommand(EntityType entityType, EntityName entityName)
             : base(entityType, entityName)

--- a/code/DeltaKustoLib/CommandModel/Policies/Merge/AlterMergePolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/Merge/AlterMergePolicyCommand.cs
@@ -18,8 +18,8 @@ namespace DeltaKustoLib.CommandModel.Policies.Merge
         public override string CommandFriendlyName => ".alter <entity> policy merge";
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/merge/create/{EntityName}"
-            : $"databases/policies/merge/create";
+            ? $"databases/policies/merge/create/{EntityName}"
+            : $"tables/policies/merge/create/{EntityName}";
 
         public AlterMergePolicyCommand(
             EntityType entityType,

--- a/code/DeltaKustoLib/CommandModel/Policies/Merge/DeleteMergePolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/Merge/DeleteMergePolicyCommand.cs
@@ -18,8 +18,8 @@ namespace DeltaKustoLib.CommandModel.Policies.Merge
         public override string CommandFriendlyName => ".delete <entity> policy merge";
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/merge/delete"
-            : $"db/policies/delete";
+            ? $"databases/policies/delete/{EntityName}"
+            : $"tables/policies/merge/delete/{EntityName}";
 
         public DeleteMergePolicyCommand(EntityType entityType, EntityName entityName)
             : base(entityType, entityName)

--- a/code/DeltaKustoLib/CommandModel/Policies/Retention/AlterRetentionPolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/Retention/AlterRetentionPolicyCommand.cs
@@ -18,8 +18,8 @@ namespace DeltaKustoLib.CommandModel.Policies.Retention
         public override string CommandFriendlyName => ".alter <entity> policy retention";
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/retention/create/{EntityName}"
-            : $"databases/policies/retention/create";
+            ? $"databases/policies/retention/{EntityName}"
+            : $"tables/policies/retention/create/{EntityName}";
 
         public AlterRetentionPolicyCommand(
             EntityType entityType,

--- a/code/DeltaKustoLib/CommandModel/Policies/Retention/DeleteRetentionPolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/Retention/DeleteRetentionPolicyCommand.cs
@@ -18,8 +18,8 @@ namespace DeltaKustoLib.CommandModel.Policies.Retention
         public override string CommandFriendlyName => ".delete <entity> policy retention";
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/retention/delete"
-            : $"db/policies/delete";
+            ? $"databases/policies/retention/delete/{EntityName}"
+            : $"tables/policies/retention/delete/{EntityName}";
 
         public DeleteRetentionPolicyCommand(EntityType entityType, EntityName entityName)
             : base(entityType, entityName)

--- a/code/DeltaKustoLib/CommandModel/Policies/Sharding/AlterShardingPolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/Sharding/AlterShardingPolicyCommand.cs
@@ -32,8 +32,8 @@ namespace DeltaKustoLib.CommandModel.Policies.Sharding
         public override string CommandFriendlyName => ".alter <entity> policy sharding";
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/sharding/create/{EntityName}"
-            : $"databases/policies/sharding/create";
+            ? $"databases/policies/sharding/create/{EntityName}"
+            : $"tables/policies/sharding/create/{EntityName}";
 
         public AlterShardingPolicyCommand(
             EntityType entityType,

--- a/code/DeltaKustoLib/CommandModel/Policies/Sharding/DeleteShardingPolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/Sharding/DeleteShardingPolicyCommand.cs
@@ -18,8 +18,8 @@ namespace DeltaKustoLib.CommandModel.Policies.Sharding
         public override string CommandFriendlyName => ".delete <entity> policy sharding";
 
         public override string ScriptPath => EntityType == EntityType.Database
-           ? $"tables/policies/sharding/delete"
-           : $"db/policies/delete";
+           ? $"databases/policies/sharding/delete/{EntityName}"
+           : $"tables/policies/sharding/delete/{EntityName}";
 
         public DeleteShardingPolicyCommand(EntityType entityType, EntityName entityName)
             : base(entityType, entityName)

--- a/code/DeltaKustoLib/CommandModel/Policies/StreamingIngestion/AlterStreamingIngestionPolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/StreamingIngestion/AlterStreamingIngestionPolicyCommand.cs
@@ -16,8 +16,8 @@ namespace DeltaKustoLib.CommandModel.Policies.StreamingIngestion
         public override string CommandFriendlyName => ".alter <entity> policy streamingingestion";
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/streamingingestion/create/{EntityName}"
-            : $"databases/policies/streamingingestion/create";
+            ? $"databases/policies/streamingingestion/create/{EntityName}"
+            : $"tables/policies/streamingingestion/create//{EntityName}";
 
         public AlterStreamingIngestionPolicyCommand(
             EntityType entityType,

--- a/code/DeltaKustoLib/CommandModel/Policies/StreamingIngestion/DeleteStreamingIngestionPolicyCommand.cs
+++ b/code/DeltaKustoLib/CommandModel/Policies/StreamingIngestion/DeleteStreamingIngestionPolicyCommand.cs
@@ -13,8 +13,8 @@ namespace DeltaKustoLib.CommandModel.Policies.StreamingIngestion
         public override string CommandFriendlyName => ".delete <entity> policy streamingingestion";
 
         public override string ScriptPath => EntityType == EntityType.Database
-            ? $"tables/policies/streamingingestion/delete"
-            : $"db/policies/delete";
+            ? $"databases/policies/streamingingestion/delete"
+            : $"tables/policies/delete";
 
         public DeleteStreamingIngestionPolicyCommand(EntityType entityType, EntityName entityName)
             : base(entityType, entityName)


### PR DESCRIPTION
Database and table policy scripts were writing to the wrong folder path. The issue was mismatched ternary operators. 

I also added the entity name to each script output